### PR TITLE
examples: client: fix missing flag.Parse()

### DIFF
--- a/examples/application/client.go
+++ b/examples/application/client.go
@@ -24,6 +24,8 @@ var (
 func main() {
 	log.Info("Hello I'm a application client")
 
+	flag.Parse()
+
 	opts := grpc.WithInsecure()
 	if *tls {
 		if *caFile == "" {


### PR DESCRIPTION
예제 어플리케이션에서 flag.Parse() 호출이 누락되어 CLI 옵션이 적용되지 않는 문제를 수정하였습니다.