### PR TITLE
Feature/add additional value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ vendor/
 .idea/
 .DS_Store
 .vscode/
+
+cmd/server/server
+

--- a/cmd/server/csp_info_handler.go
+++ b/cmd/server/csp_info_handler.go
@@ -26,6 +26,7 @@ func InitCspInfoHandler(db *gorm.DB) {
 // CreateCSPInfo create new CSP Info for the contract id.
 func (s *CspInfoServer) CreateCSPInfo(ctx context.Context, in *pb.CreateCSPInfoRequest) (*pb.IDResponse, error) {
   log.Info("Request CreateCSPInfo for contractID ", in.GetContractId())
+  log.Info("Request test for cspType ", in.GetCspType())
 
   contractId, err := uuid.Parse(in.GetContractId())
   if err != nil {
@@ -38,7 +39,7 @@ func (s *CspInfoServer) CreateCSPInfo(ctx context.Context, in *pb.CreateCSPInfoR
     return &res, err
   }
 
-  id, err := cspInfoAccessor.Create(contractId, in.GetCspName(), in.GetAuth())
+  id, err := cspInfoAccessor.Create(contractId, in.GetCspName(), in.GetAuth(), in.GetCspType() )
   if err != nil {
     return &pb.IDResponse{
       Code: pb.Code_INTERNAL,
@@ -52,6 +53,45 @@ func (s *CspInfoServer) CreateCSPInfo(ctx context.Context, in *pb.CreateCSPInfoR
     Code:  pb.Code_OK_UNSPECIFIED,
     Error: nil,
     Id:    id.String(),
+  }, nil
+}
+
+// GetCSPInfo is used to get CSP Info by id.
+func (s *CspInfoServer) GetCSPInfo(ctx context.Context, in *pb.IDRequest) (*pb.GetCSPInfoResponse, error) {
+  log.Debug("request GetCSPInfo for CSP ID ", in.GetId())
+
+  cspId, err := uuid.Parse(in.GetId())
+  if err != nil {
+    res := pb.GetCSPInfoResponse{
+      Code: pb.Code_INVALID_ARGUMENT,
+      Error: &pb.Error{
+        Msg: fmt.Sprintf("invalid csp ID %s", in.GetId()),
+      },
+    }
+    return &res, err
+  }
+  fmt.Sprintf("cspInfo %s", cspId )
+
+  cspInfo, err2 := cspInfoAccessor.GetCSPInfo(cspId)
+  if err2 != nil {
+    res := pb.GetCSPInfoResponse{
+      Code: pb.Code_NOT_FOUND,
+      Error: &pb.Error{
+        Msg: err2.Error(),
+      },
+    }
+    return &res, err2
+  }
+
+  log.Debug("cspInfo : %s ", cspInfo.Name )
+
+  return &pb.GetCSPInfoResponse{
+    Code:  pb.Code_OK_UNSPECIFIED,
+    Error: nil,
+    ContractId: cspInfo.ContractID.String(),
+    CspName: cspInfo.Name,
+    Auth: cspInfo.Auth,
+    CspType: cspInfo.CspType,
   }, nil
 }
 

--- a/cmd/server/csp_info_handler.go
+++ b/cmd/server/csp_info_handler.go
@@ -26,7 +26,6 @@ func InitCspInfoHandler(db *gorm.DB) {
 // CreateCSPInfo create new CSP Info for the contract id.
 func (s *CspInfoServer) CreateCSPInfo(ctx context.Context, in *pb.CreateCSPInfoRequest) (*pb.IDResponse, error) {
   log.Info("Request CreateCSPInfo for contractID ", in.GetContractId())
-  log.Info("Request test for cspType ", in.GetCspType())
 
   contractId, err := uuid.Parse(in.GetContractId())
   if err != nil {
@@ -82,8 +81,6 @@ func (s *CspInfoServer) GetCSPInfo(ctx context.Context, in *pb.IDRequest) (*pb.G
     }
     return &res, err2
   }
-
-  log.Debug("cspInfo : %s ", cspInfo.Name )
 
   return &pb.GetCSPInfoResponse{
     Code:  pb.Code_OK_UNSPECIFIED,

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,17 @@ require (
 	github.com/lib/pq v1.10.2
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sktelecom/tks-contract v0.1.1-0.20210604023929-73ffc015c1f1
-	github.com/sktelecom/tks-proto v0.0.6-0.20210622012523-ded9f951101f // indirect
+	github.com/sktelecom/tks-proto v0.0.6-0.20210622012523-ded9f951101f
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.38.0
-	google.golang.org/protobuf v1.26.0
+	google.golang.org/protobuf v1.27.1
 	gorm.io/datatypes v1.0.1
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/gorm v1.21.10
 )
 
-replace github.com/sktelecom/tks-info => ./
+replace (
+	github.com/sktelecom/tks-proto => ../tks-proto
+	github.com/sktelecom/tks-info => ./
+)
+

--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,5 @@ require (
 	gorm.io/gorm v1.21.10
 )
 
-replace (
-	github.com/sktelecom/tks-proto => ../tks-proto
-	github.com/sktelecom/tks-info => ./
-)
+replace github.com/sktelecom/tks-info => ./
 

--- a/go.sum
+++ b/go.sum
@@ -562,6 +562,8 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/pkg/cluster/accessor.go
+++ b/pkg/cluster/accessor.go
@@ -87,6 +87,7 @@ func (x *ClusterAccessor) CreateClusterInfo(contractId uuid.UUID, cspId uuid.UUI
     WorkerReplicas: conf.WorkerReplicas,
     WorkerRootSize: conf.WorkerRootSize,
     K8sVersion: conf.K8SVersion,
+    Region: conf.Region,
   }
 
   res := x.db.Create(&cluster)
@@ -120,6 +121,7 @@ func ConvertToPbCluster(cluster model.Cluster) *pb.Cluster {
     WorkerReplicas: cluster.WorkerReplicas,
     WorkerRootSize: cluster.WorkerRootSize,
     K8SVersion: cluster.K8sVersion,
+    Region: cluster.Region,
   }
 
   return &pb.Cluster{

--- a/pkg/cluster/accessor_test.go
+++ b/pkg/cluster/accessor_test.go
@@ -38,6 +38,7 @@ func TestCreateClusterInfo(t *testing.T) {
     WorkerReplicas: 5,
     WorkerRootSize: 50,
     K8SVersion: "1.18.8",
+    Region: "ap-southeast-2",
   }
 
   clusterId, err = clusterAccessor.CreateClusterInfo(contractId, cspId, clusterName, &dummyConf)

--- a/pkg/cluster/model/cluster.go
+++ b/pkg/cluster/model/cluster.go
@@ -23,6 +23,7 @@ type Cluster struct {
   WorkerRootSize    int64
   K8sVersion        string
   Kubeconfig        string
+  Region            string
   UpdatedAt         time.Time
   CreatedAt         time.Time
 }

--- a/pkg/csp_info/accessor.go
+++ b/pkg/csp_info/accessor.go
@@ -6,6 +6,7 @@ import (
   "gorm.io/gorm"
 
   model "github.com/sktelecom/tks-info/pkg/csp_info/model"
+  pb "github.com/sktelecom/tks-proto/pbgo"
 )
 
 // Accessor accesses to csp info in-memory data.
@@ -49,8 +50,8 @@ func (x *CspInfoAccessor) GetCSPIDsByContractID(contractId uuid.UUID) ([]string,
 }
 
 // Create creates new CSP info with contractID and auth.
-func (x *CspInfoAccessor) Create(contractId uuid.UUID, name string, auth string) (uuid.UUID, error) {
-  cspInfo := model.CSPInfo{ContractID: contractId, Name: name, Auth: auth}
+func (x *CspInfoAccessor) Create(contractId uuid.UUID, name string, auth string, cspType pb.CspType ) (uuid.UUID, error) {
+  cspInfo := model.CSPInfo{ContractID: contractId, Name: name, Auth: auth, CspType: cspType}
 
   res := x.db.Create(&cspInfo)
   if res.Error != nil {

--- a/pkg/csp_info/model/csp_info.go
+++ b/pkg/csp_info/model/csp_info.go
@@ -2,6 +2,8 @@ package model
 
 import (
   "time"
+
+  pb "github.com/sktelecom/tks-proto/pbgo"
   uuid "github.com/google/uuid"
   "gorm.io/gorm"
 )
@@ -12,6 +14,7 @@ type CSPInfo struct {
   ContractID        uuid.UUID
   Name              string
   Auth              string
+  CspType           pb.CspType
   UpdatedAt         time.Time
   CreatedAt         time.Time
 }

--- a/scripts/cluster_db.sql
+++ b/scripts/cluster_db.sql
@@ -1,3 +1,4 @@
+\c tks;
 CREATE TABLE clusters
 (
     name character varying(50) COLLATE pg_catalog."default",
@@ -13,6 +14,7 @@ CREATE TABLE clusters
     worker_root_size bigint,
     k8s_version character varying(50) COLLATE pg_catalog."default",
     kubeconfig character varying(1000) COLLATE pg_catalog."default",
+    region character varying(50) COLLATE pg_catalog."default",
     updated_at timestamp with time zone,
     created_at timestamp with time zone
 );

--- a/scripts/csp_info_db.sql
+++ b/scripts/csp_info_db.sql
@@ -1,9 +1,11 @@
+\c tks;
 CREATE TABLE csp_infos
 (
     id uuid primary key,
     contract_id uuid,
     name character varying(50) COLLATE pg_catalog."default",
     auth character varying(200) COLLATE pg_catalog."default",
+    csp_type integer,
     updated_at timestamp with time zone,
     created_at timestamp with time zone
 );


### PR DESCRIPTION
TACODEV-904 : tks의 database schema에 aws 정보를 추가한다.

주요 수정 사항
 . 외부 I/F 가 변경되었습니다. tks-info:Create()
 . database schema 가 변경되었습니다.
위의 결과로 인해 추가로 작업해야 하는 것이 있다면 안내 부탁 드립니다.

cspType 추가의 CURD 중 C 만 있는 상황이므로, 전체 cspInfo 를 조회하는 R 을 생성하였습니다.
혹시 cspType 만 조회하는 API 를 추가하는 것이 좋다고 생각되시면 의견 부탁 드립니다. 
