### PR TITLE
Fix. change secret key

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Configure git for private modules
-        run: git config --global url."https://x-access-token:$${{ secrets.PRV_GITHUB_TOKEN }}@github.com/openinfradev".insteadOf "https://github.com/openinfradev"
+        run: git config --global url."https://x-access-token:${{ secrets.PRV_GITHUB_TOKEN }}@github.com/openinfradev".insteadOf "https://github.com/openinfradev"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:


### PR DESCRIPTION
임시로 넣었던 secret 을 변경하며, 기존의 secret 은 삭제처리합니다.
PRV_GITHUB_TOKEN 을 생성하였습니다. ( /w 안승규 )

lesson learned. 
기본 generated 되는 secrets.GITHUB_TOKEN 은 repo 내 권한만 있으므로, 외부 repo 접근을 위해서는 아래의 방식을 사용함.
 1. organization secret 을 생성함 ( PRV_GITHUB_TOKEN )
 2. private repo를 접근할 수 있는 PAT( personal access token ) 를 생성하여 해당 secret 에 입력함

